### PR TITLE
create_sino uses proj_geom and vol_geom on GPU, without projector

### DIFF
--- a/astra/creators.py
+++ b/astra/creators.py
@@ -379,7 +379,8 @@ def create_sino(data, proj_id=None, proj_geom=None, vol_geom=None,
     elif proj_geom is not None and vol_geom is not None:
         if not useCUDA:
             # We need more parameters to create projector.
-            raise NotImplemented
+            raise ValueError(
+                """A ``proj_id`` is needed when CUDA is not used.""")
     else:
         raise Exception("""The geometry setup is not defined.
         The geometry of setup is defined by ``proj_id`` or with


### PR DESCRIPTION
I have fixed the error with the exception raised in case (useCUDA=False and proj_id=None).
