### PR TITLE
Add missing import

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -24,6 +24,7 @@
 #
 #-----------------------------------------------------------------------
 import sys
+import os
 import numpy as np
 
 from distutils.version import LooseVersion


### PR DESCRIPTION
This adds a missing import necessary for the use of os.environ in builder.py.
